### PR TITLE
Include data files when building source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include geogateway_django_app/static *
+recursive-include geogateway_django_app/templates *

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setuptools.setup(
     version="0.0.1",
     description="GeoGateway Django app",
     packages=setuptools.find_packages(),
+    include_package_data=True,
     install_requires=[
         'django>=1.11.16'
     ],


### PR DESCRIPTION
I ran into an issue where templates weren't included in the django app package when installed into a virtual environment. This issue isn't there when doing an "editable" install, but is there when doing a non-editable, non-development install.
