### PR TITLE
Update urls import for Django 4.2

### DIFF
--- a/geogateway_django_app/urls.py
+++ b/geogateway_django_app/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import re_path
 from django.views.generic import TemplateView
 from rest_framework import routers
 from . import GeoGatewayData
@@ -12,27 +12,27 @@ app_name = "geogateway_django_app"
 
 
 urlpatterns = [
-    url(r'^$',
+    re_path(r'^$',
         views.frontend,
         name="home",
         ),
-    url(r"^gps_service/", GeoGatewayData.gps_service),
-    url(r"^get_kml/", GeoGatewayData.get_gnss_kml),
-    url(r"^wo_forecast/", GeoGatewayData.forecast),
-    url(r"^ca_forecast/", GeoGatewayData.forecast),
-    url(r"^gdacs/", GeoGatewayData.gdacs),
-    #url(r"^nowcast/", GeoGatewayData.nowcast_plots),
-    url(r"^disloc/", GeoGatewayData.dislocInput),
-    url(r'^kml_upload/$', GeoGatewayData.kml_upload),
-    url(r"^UAVSAR_overview/", GeoGatewayData.uavsarOverview),
-    url(r"^UAVSAR_geom/", GeoGatewayData.uavsarGeometry),
-    url(r"^UAVSAR_KML/", GeoGatewayData.uavsarKML),
-    url(r"^UAVSAR_test/", GeoGatewayData.uavsarTest),
-    url(r"^UAVSAR_csv/", GeoGatewayData.uavsarCSV),
-    url(r"^UAVSAR_flight/", GeoGatewayData.uavsarFlight),
-    url(r'^kmz_upload/$', GeoGatewayData.kmz_upload),
-    url(r'^seismicity/$', GeoGatewayData.seismicity),
-    url(r'^los_download/$', GeoGatewayData.losDownload)
+    re_path(r"^gps_service/", GeoGatewayData.gps_service),
+    re_path(r"^get_kml/", GeoGatewayData.get_gnss_kml),
+    re_path(r"^wo_forecast/", GeoGatewayData.forecast),
+    re_path(r"^ca_forecast/", GeoGatewayData.forecast),
+    re_path(r"^gdacs/", GeoGatewayData.gdacs),
+    #re_path(r"^nowcast/", GeoGatewayData.nowcast_plots),
+    re_path(r"^disloc/", GeoGatewayData.dislocInput),
+    re_path(r'^kml_upload/$', GeoGatewayData.kml_upload),
+    re_path(r"^UAVSAR_overview/", GeoGatewayData.uavsarOverview),
+    re_path(r"^UAVSAR_geom/", GeoGatewayData.uavsarGeometry),
+    re_path(r"^UAVSAR_KML/", GeoGatewayData.uavsarKML),
+    re_path(r"^UAVSAR_test/", GeoGatewayData.uavsarTest),
+    re_path(r"^UAVSAR_csv/", GeoGatewayData.uavsarCSV),
+    re_path(r"^UAVSAR_flight/", GeoGatewayData.uavsarFlight),
+    re_path(r'^kmz_upload/$', GeoGatewayData.kmz_upload),
+    re_path(r'^seismicity/$', GeoGatewayData.seismicity),
+    re_path(r'^los_download/$', GeoGatewayData.losDownload)
 
 
 


### PR DESCRIPTION
`url()` was renamed to `re_path()` and moved to a different module in Django 4.